### PR TITLE
Add environment-safe log initialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-import './log';
+import { initLogging } from './log';
+
+initLogging();
 
 console.log("Hello, world!");
 console.warn("Warning!");

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,50 @@
+/**
+ * Initialize logging in a way that works in both Node.js and browsers.
+ * Node-specific handlers are only registered when `process` is detected.
+ */
+
+let initialized = false;
+
+function isNode(): boolean {
+  const g = globalThis as any;
+  return (
+    typeof g.process !== 'undefined' &&
+    !!g.process.versions?.node &&
+    typeof g.process.on === 'function'
+  );
+}
+
+function setupNode(): void {
+  const proc = (globalThis as any).process as any;
+
+  if (proc.listeners('uncaughtException').length === 0) {
+    proc.on('uncaughtException', (err: unknown) => {
+      console.error(err);
+    });
+  }
+
+  if (proc.listeners('unhandledRejection').length === 0) {
+    proc.on('unhandledRejection', (reason: unknown) => {
+      console.error('Unhandled rejection', reason);
+    });
+  }
+}
+
+function setupBrowser(): void {
+  // No-op fallback for browsers
+}
+
+export function initLogging(): void {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+
+  if (isNode()) {
+    setupNode();
+  } else {
+    setupBrowser();
+  }
+}
+
+


### PR DESCRIPTION
## Summary
- guard logging setup with runtime checks for Node.js
- expose `initLogging` without automatic side effects
- call `initLogging` explicitly from `index.ts`

## Testing
- `npm test -- --passWithNoTests` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684cdb5ecea0832ca4f02896a43d5fe3