### PR TITLE
Remove timestamp and label from logging options

### DIFF
--- a/src/log/console.ts
+++ b/src/log/console.ts
@@ -17,15 +17,8 @@ export const originalConsoleError = console.error.bind(console);
  */
 function makeCustomLogger(opts: Required<LoggingOptions>): Logger.Logger<unknown, void> {
   return Logger.make(({ logLevel, message }) => {
-    const parts: unknown[] = [];
-    if (opts.timestamp) {
-      parts.push(new Date().toISOString());
-    }
-    if (opts.label) {
-      parts.push(`[${logLevel.label}]`);
-    }
     const msg = Array.isArray(message) ? message : [message];
-    originalConsoleLog(...parts, ...msg);
+    originalConsoleLog(...msg);
   });
 }
 
@@ -41,15 +34,11 @@ function parseOptions(args: unknown[]): [unknown[], LoggingOptions] {
     const maybeOpts = args[args.length - 1] as Record<string, unknown>;
     const hasOpts =
       'pretty' in maybeOpts ||
-      'raw' in maybeOpts ||
-      'timestamp' in maybeOpts ||
-      'label' in maybeOpts;
+      'raw' in maybeOpts;
     if (hasOpts) {
       const opts: LoggingOptions = {
         pretty: maybeOpts.pretty as boolean | undefined,
         raw: maybeOpts.raw as boolean | undefined,
-        timestamp: maybeOpts.timestamp as boolean | undefined,
-        label: maybeOpts.label as boolean | undefined,
       };
       return [args.slice(0, -1), opts];
     }

--- a/src/log/options.ts
+++ b/src/log/options.ts
@@ -6,8 +6,6 @@ import { LoggingOptions } from './types';
  */
 export let globalOptions: Required<LoggingOptions> = {
   pretty: false,
-  timestamp: false,
-  label: true,
   raw: false,
 };
 

--- a/src/log/types.ts
+++ b/src/log/types.ts
@@ -4,10 +4,6 @@
 export interface LoggingOptions {
   /** Enable pretty logging using `Logger.pretty`. */
   pretty?: boolean;
-  /** Prepend timestamps to each log message. */
-  timestamp?: boolean;
-  /** Include the log level label in messages. */
-  label?: boolean;
   /** Use the native console methods instead of Effect. */
   raw?: boolean;
 }


### PR DESCRIPTION
## Summary
- simplify `LoggingOptions` by dropping `timestamp` and `label`
- update console logger to stop parsing these fields
- adjust global logging defaults

## Testing
- `npm run build`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684e096bc3e8832ca2846e2f727c0244